### PR TITLE
Scale usage by billing period

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Energy-Comparison-NI
+
+A simple browser-based tool to compare Northern Ireland Economy 7 electricity tariffs. Enter your average daily day and night usage along with the number of days in your billing period to estimate costs across suppliers.

--- a/index.html
+++ b/index.html
@@ -91,12 +91,12 @@
   <h1>NI Economy 7 Electricity Price Comparison</h1>
 
   <div class="input-group">
-    <label for="dayUsage">Day Usage (kWh):</label>
-    <input type="number" id="dayUsage" value="106.7">
+    <label for="dayUsage">Day Usage (kWh/day):</label>
+    <input type="number" id="dayUsage" value="3.56">
   </div>
   <div class="input-group">
-    <label for="nightUsage">Night Usage (kWh):</label>
-    <input type="number" id="nightUsage" value="160">
+    <label for="nightUsage">Night Usage (kWh/day):</label>
+    <input type="number" id="nightUsage" value="5.33">
   </div>
   <div class="input-group">
     <label for="days">Billing Period (days):</label>
@@ -133,13 +133,20 @@
       const nightUsage = parseFloat(document.getElementById("nightUsage").value);
       const days = parseInt(document.getElementById("days").value);
 
+      const totalDay = dayUsage * days;
+      const totalNight = nightUsage * days;
+
       const tbody = document.querySelector("#results tbody");
       tbody.innerHTML = "";
 
-      const results = tariffs.map(t => {
-        const cost = ((t.day * dayUsage + t.night * nightUsage) / 100 + (t.standing * days) / 100).toFixed(2);
-        return { ...t, total: parseFloat(cost) };
-      }).sort((a, b) => a.total - b.total);
+      const results = tariffs
+        .map(t => {
+          const energyCost = (t.day * totalDay + t.night * totalNight) / 100;
+          const standingCost = (t.standing * days) / 100;
+          const cost = (energyCost + standingCost).toFixed(2);
+          return { ...t, total: parseFloat(cost) };
+        })
+        .sort((a, b) => a.total - b.total);
 
       for (const t of results) {
         const row = `<tr>


### PR DESCRIPTION
## Summary
- Scale energy cost calculations by billing period to avoid under/over estimating when the period changes.
- Clarify usage inputs as per-day values and adjust defaults accordingly.
- Document tool usage in README.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689094cb510c832da0effefb5b03f9dc